### PR TITLE
feature(training): no more memory leaks

### DIFF
--- a/src/Model.py
+++ b/src/Model.py
@@ -1,6 +1,6 @@
 import abc
-from typing import Any, Self
 from pathlib import Path
+from typing import Any, Self
 
 import torch
 from torch.nn import Module


### PR DESCRIPTION
# [GH-XXX] Type: Brief Description

## Summary
no more memory leaks

## Related Issue
Closes #XXX

## Changes Made
- Change 1
- Change 2
- Change 3

## Type of Change
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Code refactoring
- [ ] Performance improvement
- [ ] Test addition/update

## Component(s) Affected
- [ ] Vision Model (VQ-VAE)
- [ ] Memory Model (TemporalTransformer)
- [ ] Controller (Discrete/Continuous)
- [ ] WorldModel Orchestrator
- [ ] Training Scripts
- [ ] Tests
- [ ] Documentation
- [ ] Other: ___________

## Testing
- [ ] Unit tests added/updated
- [ ] All existing tests passing
- [ ] Type checking passes (`mypy src/`)
- [ ] Manual testing completed
- [ ] Tested on: [environment, e.g., CartPole-v1, CPU/GPU]

## Code Quality Checklist
- [ ] Code follows project style guidelines
- [ ] All functions have type hints
- [ ] Docstrings added/updated (Google style)
- [ ] No mypy errors
- [ ] PR is focused on single issue
- [ ] Maximum 3-5 files changed (excluding tests)
- [ ] Commit messages follow conventions

## Documentation
- [ ] README.md updated (if needed)
- [ ] ARCHITECTURE_DECISIONS.md updated (if architectural change)
- [ ] Docstrings updated
- [ ] Comments added where logic is non-obvious

## Breaking Changes
If this is a breaking change, describe:
- What breaks
- Migration path for users
- Why this breaking change is necessary

## Screenshots/Output (if applicable)
Paste screenshots, logs, or example output here.

## Additional Notes
Any additional information reviewers should know.

---

**Reviewer Checklist** (for maintainers):
- [ ] Code quality meets standards
- [ ] Tests are comprehensive
- [ ] Documentation is clear
- [ ] No unnecessary changes
- [ ] Commit messages are descriptive
